### PR TITLE
fix: ouput

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tee"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c12559dba7383625faaff75be24becf35bfc885044375bcab931111799a3da"
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +579,7 @@ dependencies = [
  "anyhow",
  "clap",
  "primitive-types",
+ "tee",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ path = "src/main.rs"
 anyhow = "1.0.92"
 clap = { version = "4.5.21", features = ["cargo", "derive"] }
 primitive-types = "0.13.1"
+tee = "0.1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use clap::{crate_authors, Parser};
 use std::fs::File;
 use std::io::{self, stdout, IsTerminal, Read};
-
+use std::io::Cursor;
 #[derive(Parser)]
 #[command(
     name = "youdusa",
@@ -49,7 +49,20 @@ fn main() -> anyhow::Result<()> {
 
     let input: Box<dyn Read + 'static> = if !stdin.is_terminal() {
         // piped input
-        Box::new(io::stdin())
+
+        println!("Running Medusa with Youdusa help");
+        println!(
+            "╔════════════════╗\n\
+             ║    \x1B[31mYoudusa\x1B[0m     ║\n\
+             ╚════════════════╝\n");
+
+        let mut buffer = Vec::new();
+        stdin.lock().read_to_end(&mut buffer).context("failed to read pipe")?;
+
+        println!("{}", String::from_utf8_lossy(&buffer));
+
+        // Box::new(io::stdin())
+        Box::new(Cursor::new(buffer))
     } else {
         // file provided
         match &args.file {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Context;
 use clap::{crate_authors, Parser};
 use std::fs::File;
-use std::io::{self, stdout, IsTerminal, Read};
 use std::io::Cursor;
+use std::io::{self, stdout, IsTerminal, Read};
 #[derive(Parser)]
 #[command(
     name = "youdusa",
@@ -49,15 +49,18 @@ fn main() -> anyhow::Result<()> {
 
     let input: Box<dyn Read + 'static> = if !stdin.is_terminal() {
         // piped input
-
         println!("Running Medusa with Youdusa help");
         println!(
             "╔════════════════╗\n\
              ║    \x1B[31mYoudusa\x1B[0m     ║\n\
-             ╚════════════════╝\n");
+             ╚════════════════╝\n"
+        );
 
         let mut buffer = Vec::new();
-        stdin.lock().read_to_end(&mut buffer).context("failed to read pipe")?;
+        stdin
+            .lock()
+            .read_to_end(&mut buffer)
+            .context("failed to read pipe")?;
 
         println!("{}", String::from_utf8_lossy(&buffer));
 


### PR DESCRIPTION
closes BES-422
closes #7 

- Use Tee crate
- In main.rs, if the input is from a pipe, tee it to have it processed and output on stdout
- Do not use a buffer, to avoid unbounded mem use (long lasting run)

