### PR TITLE
feat: contract template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,10 +310,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -278,6 +393,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "ppv-lite86"
@@ -464,6 +585,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +704,7 @@ name = "youdusa"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "askama",
  "clap",
  "primitive-types",
  "tee",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.92"
+askama = "0.12.1"
 clap = { version = "4.5.21", features = ["cargo", "derive"] }
 primitive-types = "0.13.1"
 tee = "0.1.0"

--- a/src/contract_writer.rs
+++ b/src/contract_writer.rs
@@ -1,0 +1,43 @@
+use anyhow::{Context, Result, anyhow};
+use askama::Template;
+use std::fs::File;
+use std::io::Write as WriteIO;
+use std::path::Path;
+
+/// The contract template,
+#[derive(Template, Debug, Clone, PartialEq)]
+#[template(path = "template.sol", escape = "none")]
+pub struct Contract {
+    reproducers: String,
+    contract_name: String,
+}
+
+impl Contract {
+    pub fn new(reproducers: &[u8]) -> Result<Contract> {
+        let contract_name = Contract::find_first_unused_filename().context("Failed to find a filename")?;
+
+        Ok(Contract { reproducers: String::from_utf8_lossy(reproducers).to_string(), contract_name })
+    }
+
+    pub fn write_rendered_contract(&self) -> Result<()> {
+        let mut f = File::create_new(format!("{}.t.sol", self.contract_name))
+            .context(format!("Failed to create contract"))?;
+
+        let rendered = self
+            .render()
+            .context(format!("Fail to render contract"))?;
+
+        f.write_all(rendered.as_bytes())
+            .context(format!("Failed to write contract"))?;
+
+        Ok(())
+    }
+
+    fn find_first_unused_filename() -> Result<String> {
+        // Avoiding Regex intensifies
+        (0..)
+            .map(|i| if i == 0 { "ForgeReproducer".to_owned() } else { format!("ForgeReproducer{}", i) })
+            .find(|base| !Path::new(&format!("{}{}", base, ".t.sol")).exists())
+            .ok_or_else(|| anyhow!("No available filename found"))
+    }
+}

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -53,7 +53,7 @@ impl Emitter {
         }
 
         self.output.push_str(&" ".repeat(self.default_indentation));
-        self.output.push_str("}\n");
+        self.output.push_str("}");
     }
 
     fn emit_statement(&mut self, statement: &Statement) {

--- a/templates/template.sol
+++ b/templates/template.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {FuzzTest} from './FuzzTest.t.sol';
+import {vm} from './Setup.t.sol';
+
+contract {{ contract_name }} is FuzzTest {
+{{ reproducers }}
+}


### PR DESCRIPTION
closes BES-427
closes #12 

Add the following contract template and fill it with the reproducer function:
```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.0;

import {FuzzTest} from './FuzzTest.t.sol';
import {vm} from './Setup.t.sol';

contract ForgeReproducer is FuzzTest {

}
```

If the contract already exists, append a number after.

Hide this behaviour behind the bool flag `--write-contract`